### PR TITLE
add missing package that is required to run gst-inspect-1.0 in step 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following two methods compile the latest development version of
 
 ## Native compile
 
-On a low-power device (e.g. Raspberry Pi), the compile will be slow and `cargo` may require 
+On a low-power device (e.g. Raspberry Pi), the compile will be slow and `cargo` may require
 an additional `--jobs 1` argument to prevent memory exhaustion.
 
 Example build instructions for `gst-plugins-spotify`:
@@ -37,7 +37,7 @@ Example build instructions for `gst-plugins-spotify`:
    dependencies:
 
    ```
-   sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev clang gcc pkg-config git
+   sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev clang gcc pkg-config git gstreamer1.0-tools
    ```
 
    Note that other plugins may require additional dependencies.


### PR DESCRIPTION
The instructions work up to step 4 of the Native compile section, which errors out because gstreamer1.0-tools is not installed. This PR updates that.