### PR TITLE
feat: Encode branch and short hash into the .deb version

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -143,8 +143,18 @@ jobs:
 
     - name: Create deb package
       run: |
+        # Compose a .deb version that records what was actually built — branch
+        # + short hash — so fork/branch builds are distinguishable from
+        # upstream at a glance. Sanitize the branch to Debian's allowed
+        # upstream_version chars.
+        PKG_VERSION=$(cd ${GST_SRC_DIR} && cargo pkgid | sed 's/.*[#@]//')
+        GIT_HASH=$(git -C gst-plugins-rs rev-parse --short HEAD)
+        BRANCH_TAG=$(echo -n "$GST_GIT_BRANCH" | tr -c 'A-Za-z0-9.+~-' '.' | sed 's/\.\.*/./g; s/^\.//; s/\.$//')
+        REVISION=$(grep -E '^\s*revision\s*=' Cargo.toml.deb | sed -E 's/.*"([^"]+)".*/\1/')
+        DEB_VERSION="${PKG_VERSION}+${BRANCH_TAG}.${GIT_HASH}-${REVISION}"
+        echo "Building deb version: $DEB_VERSION"
         pushd ${GST_SRC_DIR}
-        cargo deb -v --target=${TARGET} --no-build
+        cargo deb -v --target=${TARGET} --no-build --deb-version "$DEB_VERSION"
    
     - name: Check deb
       run: |

--- a/Cargo.toml.deb
+++ b/Cargo.toml.deb
@@ -3,4 +3,4 @@ maintainer = 'Nick Steel <nick@nsteel.co.uk>'
 assets = [
     ['target/release/libgstspotify.so', '%GST_PLUGINS_DIR%/', '644'],
 ]
-revision = "4"
+revision = "0mopidy1"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,11 +76,20 @@ cat Cargo.toml.deb >> ${GST_SRC_DIR}/Cargo.toml
 TARGET_PLUGINS_DIR=$(pkg-config --variable=pluginsdir gstreamer-1.0)
 sed -i "s@%GST_PLUGINS_DIR%@$TARGET_PLUGINS_DIR@" ${GST_SRC_DIR}/Cargo.toml
 
-log "Build Debian package"
+# Compose a .deb version that records what was actually built — branch +
+# short hash — so fork/branch builds are distinguishable from upstream at a
+# glance. Sanitize the branch to Debian's allowed upstream_version chars.
+PKG_VERSION=$(cd ${GST_SRC_DIR} && cargo pkgid | sed 's/.*[#@]//')
+GIT_HASH=$(git -C gst-plugins-rs rev-parse --short HEAD)
+BRANCH_TAG=$(echo -n "$GST_GIT_BRANCH" | tr -c 'A-Za-z0-9.+~-' '.' | sed 's/\.\.*/./g; s/^\.//; s/\.$//')
+REVISION=$(grep -E '^\s*revision\s*=' Cargo.toml.deb | sed -E 's/.*"([^"]+)".*/\1/')
+DEB_VERSION="${PKG_VERSION}+${BRANCH_TAG}.${GIT_HASH}-${REVISION}"
+
+log "Build Debian package as $DEB_VERSION"
 # Must specify target despite no-build else cargo-deb looks in the workspace for the asset, see comment at top.
 #WITH_DEBUG=" --separate-debug-symbols"
 pushd ${GST_SRC_DIR}
-cargo deb --target=$TARGET --no-build $WITH_DEBUG -v
+cargo deb --target=$TARGET --no-build --deb-version "$DEB_VERSION" $WITH_DEBUG -v
 popd
 
 DEB_FILE=$(find gst-plugins-rs/target/$TARGET/debian/*.deb)


### PR DESCRIPTION
When this repo is run against a fork or non-default branch (the common
case — the published builds carry an extra logging commit), the .deb
filename was indistinguishable from an upstream build. cargo deb's
auto-derived version is just <cargo_version>-<revision>, with no signal
that what got built isn't gst-plugins-rs main.

This composes a richer version for cargo deb's --deb-version flag:

    <cargo_version>+<branch>.<shorthash>-<revision>

Examples:
    0.15.1+0.15.1.abc1234-0kingosticks1   (upstream tag build)
    0.15.1+spotify-logging.a3e8681-0kingosticks1  (fork branch)

Fixes https://github.com/kingosticks/gst-plugins-rs-build/issues/7

## Result

...when combined with #12:

```console
$ GST_GIT_REPO=https://gitlab.freedesktop.org/kingosticks/gst-plugins-rs.git GST_GIT_BRANCH=spotify-logging make build-x86_64
$ find gst-plugins-rs/ -name '*.deb'
gst-plugins-rs/target/x86_64-unknown-linux-gnu/debian/gst-plugin-spotify_0.15.0-alpha.1+spotify-logging.3aab047-0kingosticks1_amd64.deb
gst-plugins-rs/target/debian/gst-plugin-spotify_0.15.0-alpha.1+spotify-logging.3aab047-0kingosticks1_amd64.deb
```