### PR TITLE
fix: Include libs for all arches in releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,17 @@ jobs:
         # (LINKER, LINKER_TOOLS, PKG_CONFIG_PATH, CARGO_TARGET_<TRIPLE>_*).
         run: package/cross-env.sh "${{ matrix.arch }}" >> $GITHUB_ENV
 
-      - name: Capture plugin name+version
+      - name: Capture plugin name and versions
+        # Naming mirrors local dist/ output:
+        #   <pkg>_<so-version>_<arch>            (subdir holding the bare .so)
+        #   <pkg>_<deb-version>_<arch>.deb       (flat .deb filename)
+        # so the artifact names line up with what cargo-deb produces and what
+        # package/build.sh writes locally.
         run: |
-          echo "PLUGIN_NAME_VER=$(cd ${GST_SRC_DIR} && cargo pkgid | cut -d '#' -f2)" >> $GITHUB_ENV
+          PKG_NAME=$(cd ${GST_SRC_DIR} && cargo pkgid | sed -e 's/.*#//' -e 's/@.*//')
+          echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
+          echo "SO_VERSION=$(package/compose-version.sh "${GST_SRC_DIR}")" >> $GITHUB_ENV
+          echo "DEB_VERSION=$(package/compose-version.sh --deb "${GST_SRC_DIR}")" >> $GITHUB_ENV
 
       - name: Compile plugin
         run: |
@@ -106,7 +114,7 @@ jobs:
       - name: Upload lib
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PLUGIN_NAME_VER }} ${{ env.TARGET }} lib
+          name: ${{ env.PKG_NAME }}_${{ env.SO_VERSION }}_${{ matrix.arch }}_lib
           path: ${{ env.SO_FILE }}
 
       - name: Build .deb
@@ -117,5 +125,5 @@ jobs:
       - name: Upload deb
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PLUGIN_NAME_VER }} ${{ env.TARGET }} Debian Package
+          name: ${{ env.PKG_NAME }}_${{ env.DEB_VERSION }}_${{ matrix.arch }}_deb
           path: ${{ env.DEB_FILE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       container_version: ${{ steps.container.outputs.version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find latest container version
         id: container
@@ -52,7 +52,7 @@ jobs:
     name: ${{ inputs.gst_plugin }} / ${{ inputs.gst_version }} / ${{ matrix.arch }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set TARGET for rustup
         # Just TARGET — full cross-compile env is set later, after cargo install
@@ -76,7 +76,7 @@ jobs:
       - name: Cache cargo stuff
         env:
           CONTAINER_VERSION: gst-plugins-rs-build:${{ needs.bust-cache.outputs.container_version }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo
@@ -112,7 +112,7 @@ jobs:
           echo "SO_FILE=$SO_FILE" >> $GITHUB_ENV
 
       - name: Upload lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PKG_NAME }}_${{ env.SO_VERSION }}_${{ matrix.arch }}_lib
           path: ${{ env.SO_FILE }}
@@ -123,7 +123,7 @@ jobs:
           echo "DEB_FILE=$DEB_FILE" >> $GITHUB_ENV
 
       - name: Upload deb
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PKG_NAME }}_${{ env.DEB_VERSION }}_${{ matrix.arch }}_deb
           path: ${{ env.DEB_FILE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,16 @@ on:
   workflow_call:
     inputs:
       gst_repo:
-        description: 'gst-plugins-rs source repo'
-        default: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git'
+        description: "gst-plugins-rs source repo"
+        default: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
         type: string
       gst_version:
-        description: 'gst-plugins-rs branch/tag'
-        default: 'main'
+        description: "gst-plugins-rs branch/tag"
+        default: "main"
         type: string
       gst_plugin:
-        description: 'path to plugin'
-        default: 'audio/spotify'
+        description: "path to plugin"
+        default: "audio/spotify"
         type: string
 
 defaults:
@@ -28,13 +28,13 @@ jobs:
     outputs:
       container_version: ${{ steps.container.outputs.version }}
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Find latest container version
-      id: container
-      run: |
-        echo "version=$(cat images/VERSION)" >> $GITHUB_OUTPUT
+      - name: Find latest container version
+        id: container
+        run: |
+          echo "version=$(cat images/VERSION)" >> $GITHUB_OUTPUT
 
   main:
     env:
@@ -51,71 +51,71 @@ jobs:
     needs: bust-cache
     name: ${{ inputs.gst_plugin }} / ${{ inputs.gst_version }} / ${{ matrix.arch }}
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Set TARGET for rustup
-      # Just TARGET — full cross-compile env is set later, after cargo install
-      # cargo-deb (a host build that would trip over cross-target settings).
-      run: |
-        package/cross-env.sh "${{ matrix.arch }}" | grep '^TARGET=' >> $GITHUB_ENV
-        echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
+      - name: Set TARGET for rustup
+        # Just TARGET — full cross-compile env is set later, after cargo install
+        # cargo-deb (a host build that would trip over cross-target settings).
+        run: |
+          package/cross-env.sh "${{ matrix.arch }}" | grep '^TARGET=' >> $GITHUB_ENV
+          echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
-        targets: ${{ env.TARGET }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{ env.TARGET }}
 
-    - name: Checkout gst-plugins-rs
-      run: |
-        git clone --depth 1 -b ${{ env.GST_GIT_BRANCH }} ${{ env.GST_GIT_REPO }}
-        git config --global --add safe.directory /__w/gst-plugins-rs-build/gst-plugins-rs-build
-        git status && git remote -v && git log -n 1
+      - name: Checkout gst-plugins-rs
+        run: |
+          git clone --depth 1 -b ${{ env.GST_GIT_BRANCH }} ${{ env.GST_GIT_REPO }}
+          git config --global --add safe.directory /__w/gst-plugins-rs-build/gst-plugins-rs-build
+          git status && git remote -v && git log -n 1
 
-    - name: Cache cargo stuff
-      env:
-        CONTAINER_VERSION: gst-plugins-rs-build:${{ needs.bust-cache.outputs.container_version }}
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo
-          gst-plugins-rs/target/${{ env.TARGET }}/release
-        key: ${{ env.CONTAINER_VERSION }}-${{ env.TARGET }}
-        restore-keys: |
-          ${{ env.CONTAINER_VERSION }}-
+      - name: Cache cargo stuff
+        env:
+          CONTAINER_VERSION: gst-plugins-rs-build:${{ needs.bust-cache.outputs.container_version }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            gst-plugins-rs/target/${{ env.TARGET }}/release
+          key: ${{ env.CONTAINER_VERSION }}-${{ env.TARGET }}
+          restore-keys: |
+            ${{ env.CONTAINER_VERSION }}-
 
-    - name: Install cargo-deb
-      # Pinned; keep in sync with package/build.sh.
-      run: cargo install cargo-deb@3.4.1 --locked
+      - name: Install cargo-deb
+        # Pinned; keep in sync with package/build.sh.
+        run: cargo install cargo-deb@3.4.1 --locked
 
-    - name: Configure cross-compile environment
-      # Now that cargo install is done, set the rest of the cross env
-      # (LINKER, LINKER_TOOLS, PKG_CONFIG_PATH, CARGO_TARGET_<TRIPLE>_*).
-      run: package/cross-env.sh "${{ matrix.arch }}" >> $GITHUB_ENV
+      - name: Configure cross-compile environment
+        # Now that cargo install is done, set the rest of the cross env
+        # (LINKER, LINKER_TOOLS, PKG_CONFIG_PATH, CARGO_TARGET_<TRIPLE>_*).
+        run: package/cross-env.sh "${{ matrix.arch }}" >> $GITHUB_ENV
 
-    - name: Capture plugin name+version
-      run: |
-        echo "PLUGIN_NAME_VER=$(cd ${GST_SRC_DIR} && cargo pkgid | cut -d '#' -f2)" >> $GITHUB_ENV
+      - name: Capture plugin name+version
+        run: |
+          echo "PLUGIN_NAME_VER=$(cd ${GST_SRC_DIR} && cargo pkgid | cut -d '#' -f2)" >> $GITHUB_ENV
 
-    - name: Compile plugin
-      run: |
-        SO_FILE=$(package/compile-plugin.sh "${{ inputs.gst_plugin }}")
-        echo "SO_FILE=$SO_FILE" >> $GITHUB_ENV
+      - name: Compile plugin
+        run: |
+          SO_FILE=$(package/compile-plugin.sh "${{ inputs.gst_plugin }}")
+          echo "SO_FILE=$SO_FILE" >> $GITHUB_ENV
 
-    - name: Upload lib
-      uses: actions/upload-artifact@v4
-      with:
+      - name: Upload lib
+        uses: actions/upload-artifact@v4
+        with:
           name: ${{ env.PLUGIN_NAME_VER }} ${{ env.TARGET }} lib
           path: ${{ env.SO_FILE }}
 
-    - name: Build .deb
-      run: |
-        DEB_FILE=$(package/make-deb.sh "${{ inputs.gst_plugin }}")
-        echo "DEB_FILE=$DEB_FILE" >> $GITHUB_ENV
+      - name: Build .deb
+        run: |
+          DEB_FILE=$(package/make-deb.sh "${{ inputs.gst_plugin }}")
+          echo "DEB_FILE=$DEB_FILE" >> $GITHUB_ENV
 
-    - name: Upload deb
-      uses: actions/upload-artifact@v4
-      with:
+      - name: Upload deb
+        uses: actions/upload-artifact@v4
+        with:
           name: ${{ env.PLUGIN_NAME_VER }} ${{ env.TARGET }} Debian Package
           path: ${{ env.DEB_FILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
     steps:
       - name: Download everything we built
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -63,7 +63,7 @@ jobs:
           echo "NAME_AND_VERSION=$(basename "$zip" | cut -d '_' -f -2)" >> $GITHUB_ENV
 
       - name: Draft the release
-        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+        uses: softprops/action-gh-release@v3
         with:
           files: release/*
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       gst_repo:
-        description: 'gst-plugins-rs source repo'
+        description: "gst-plugins-rs source repo"
         required: true
-        default: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git'
+        default: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
         type: string
       gst_version:
-        description: 'gst-plugins-rs branch/tag'
+        description: "gst-plugins-rs branch/tag"
         required: true
-        default: 'main'
+        default: "main"
         type: string
       gst_plugin:
-        description: 'path to plugin'
+        description: "path to plugin"
         required: true
-        default: 'audio/spotify'
+        default: "audio/spotify"
         type: string
 
 jobs:
@@ -31,8 +31,8 @@ jobs:
     name: Prepare release
     needs: build
     runs-on: ubuntu-latest
-    permissions: 
-          contents: write
+    permissions:
+      contents: write
     steps:
       - name: Download everything we built
         uses: actions/download-artifact@v4
@@ -50,7 +50,5 @@ jobs:
         with:
           files: stuff/*
           draft: true
-          name: '${{ env.NAME_AND_VERSION }}'
-          body: '${{ github.event.inputs.gst_repo }} ${{ github.event.inputs.gst_plugin }} v${{ github.event.inputs.gst_version }}'
-          
-        
+          name: "${{ env.NAME_AND_VERSION }}"
+          body: "${{ github.event.inputs.gst_repo }} ${{ github.event.inputs.gst_plugin }} v${{ github.event.inputs.gst_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,35 @@ jobs:
       - name: Download everything we built
         uses: actions/download-artifact@v4
         with:
-          path: stuff
-          merge-multiple: true
+          path: artifacts
+
+      - name: Stage release files
+        # Artifact names from build.yml end in _deb or _lib. The .deb files
+        # already carry their arch in the cargo-deb filename, so drop them in
+        # flat. The lib artifacts hold a plain libgstspotify.so, so we zip
+        # each subdir (which carries the arch) to keep the .so filename
+        # pristine and avoid arch collisions.
+        shell: bash
+        run: |
+          mkdir release
+          cp artifacts/*_deb/*.deb release/
+          for d in artifacts/*_lib/; do
+            name=$(basename "$d" _lib)
+            (cd "$d" && zip "$GITHUB_WORKSPACE/release/${name}.zip" -- *)
+          done
 
       - name: Find versions
+        # Pull name+version from a .zip (lib) filename rather than a .deb so
+        # the release title omits the Debian -<revision> suffix.
         run: |
-          ls -R stuff
-          echo "NAME_AND_VERSION=$(ls stuff | head -n 1 | cut -d '_' -f -2)" >> $GITHUB_ENV
+          ls -R release
+          zip=$(ls release/*.zip | head -n 1)
+          echo "NAME_AND_VERSION=$(basename "$zip" | cut -d '_' -f -2)" >> $GITHUB_ENV
 
       - name: Draft the release
         uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
         with:
-          files: stuff/*
+          files: release/*
           draft: true
           name: "${{ env.NAME_AND_VERSION }}"
           body: "${{ github.event.inputs.gst_repo }} ${{ github.event.inputs.gst_plugin }} v${{ github.event.inputs.gst_version }}"


### PR DESCRIPTION
This PR improves the artifact names to be similar to the `dist/*` names locally.

Further, it attempts to fix the release workflow, so that we ship the bare library for each arch, and not just one of them due to the identical `libgstspotify.so` filename.